### PR TITLE
feat(videos): add videos page with talks and tutorials

### DIFF
--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import VideosContent from "./videos-content";
+
+export const metadata: Metadata = {
+  title: "Videos",
+  description:
+    "Conference talks, tutorials, and podcasts about React Native development.",
+};
+
+export default function VideosPage() {
+  return (
+    <div className="mt-10">
+      <VideosContent />
+    </div>
+  );
+}

--- a/app/videos/videos-content.tsx
+++ b/app/videos/videos-content.tsx
@@ -1,0 +1,161 @@
+import Link from "next/link";
+import { FaYoutube } from "react-icons/fa";
+
+type Video = {
+  id: string;
+  title: string;
+  event: string;
+  date: string;
+  url: string;
+  description: string;
+};
+
+const conferencesTalks: Video[] = [
+  {
+    id: "rn-optimization-2025",
+    title: "Tips & Tricks From the Ultimate Guide to RN Optimization 2025",
+    event: "React Universe Meetup SF",
+    date: "2025",
+    url: "https://www.youtube.com/watch?v=rINiwWnYrJE",
+    description:
+      "Practical performance tactics from the Ultimate Guide to React Native Optimization 2025.",
+  },
+  {
+    id: "feel-native",
+    title: "Make Your React (Native) App Feel Native",
+    event: "React Universe Meetup Wrocław",
+    date: "April 2024",
+    url: "https://www.youtube.com/watch?v=qT2xZ1S1X8g",
+    description:
+      "What makes an app feel truly native and how to achieve it in React Native across platforms.",
+  },
+  {
+    id: "visionpro-geekconf",
+    title: "React Native Apple Vision Pro",
+    event: "The Geek Conf",
+    date: "2024",
+    url: "https://www.youtube.com/watch?v=WSmf7t5EnDk",
+    description:
+      "How React Native was adapted for Apple's Vision Pro and building for visionOS.",
+  },
+  {
+    id: "visionpro-ruc",
+    title: "React Native ❤️ Apple Vision Pro: Your App in the New Dimension",
+    event: "React Universe Conf 2024",
+    date: "September 2024",
+    url: "https://www.youtube.com/watch?v=rGpVxi6oS68",
+    description:
+      "Enabling JavaScript-based apps to run natively on Apple Vision Pro.",
+  },
+];
+
+const podcasts: Video[] = [
+  {
+    id: "v0-ios",
+    title: "Building v0 iOS and Fixing React Native Along the Way",
+    event: "React Universe On Air",
+    date: "2025",
+    url: "https://www.youtube.com/watch?v=rhLBFKlEXPM",
+    description:
+      "How the v0 mobile app was built with React Native and Expo while achieving a native iOS feel.",
+  },
+  {
+    id: "visionpro-podcast",
+    title: "React Native for Apple Vision Pro and visionOS",
+    event: "React Universe On Air",
+    date: "December 2023",
+    url: "https://www.youtube.com/watch?v=RCNi8fToMBA",
+    description:
+      "Discussion about the experimental journey of bringing React Native to Apple Vision Pro.",
+  },
+];
+
+const tutorials: Video[] = [
+  {
+    id: "turbomodules-complete",
+    title: "Building React Native TurboModules with Swift - Complete Tutorial",
+    event: "YouTube",
+    date: "2025",
+    url: "https://www.youtube.com/watch?v=cMAgfQ6Fz9U",
+    description:
+      "Full guide covering project setup, TypeScript spec, Codegen, and bridging Swift to Objective-C.",
+  },
+  {
+    id: "turbomodules-events",
+    title: "Building React Native TurboModules with Swift - Event Emitting",
+    event: "YouTube",
+    date: "2025",
+    url: "https://www.youtube.com/watch?v=WArl-7O6e0w",
+    description:
+      "Implementing event emitting with Swift, ARC, fixing retain cycles, and testing in JavaScript.",
+  },
+];
+
+function VideoCard({ video }: { video: Video }) {
+  return (
+    <Link
+      href={video.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block group"
+    >
+      <article className="py-4 border-b border-gray-200 dark:border-gray-800 last:border-b-0">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
+              {video.title}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {video.event} · {video.date}
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+              {video.description}
+            </p>
+          </div>
+          <FaYoutube className="w-5 h-5 text-gray-400 dark:text-gray-500 group-hover:text-red-500 transition-colors flex-shrink-0 mt-1" />
+        </div>
+      </article>
+    </Link>
+  );
+}
+
+function VideoSection({ title, videos }: { title: string; videos: Video[] }) {
+  return (
+    <div className="mb-10">
+      <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+        {title}
+      </h2>
+      <div>
+        {videos.map((video) => (
+          <VideoCard key={video.id} video={video} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function VideosContent() {
+  return (
+    <section>
+      <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+        Videos
+      </h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8">
+        Conference talks, tutorials, and podcast appearances. Subscribe to my{" "}
+        <Link
+          href="https://www.youtube.com/@okwasniewski-dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+        >
+          YouTube channel
+        </Link>{" "}
+        for more content.
+      </p>
+
+      <VideoSection title="Conference Talks" videos={conferencesTalks} />
+      <VideoSection title="Podcasts" videos={podcasts} />
+      <VideoSection title="Tutorials" videos={tutorials} />
+    </section>
+  );
+}

--- a/content/blog/react-native-change-native-background-color.mdx
+++ b/content/blog/react-native-change-native-background-color.mdx
@@ -1,7 +1,7 @@
 
 export const meta = {
   title: 'How to change root view background color in React Native for iOS?',
-  subtitle: 'Adjust background color of the root view in React Native for iOS that works with appearance changes.',
+  subtitle: 'Root-view background that adapts to light/dark mode on iOS',
   date: '2023-12-02',
   badges: [
     {
@@ -37,7 +37,7 @@ then `cd` into your project and open the project in Xcode:
 xed ios
 ```
 
-Now open `AppDelegate.mm` and override following method: 
+Now open `AppDelegate.mm` and override following method:
 
 ```objc title="AppDelegate.mm"
 - (UIView *)createRootViewWithBridge:(RCTBridge *)bridge moduleName:(NSString *)moduleName initProps:(NSDictionary *)initProps {
@@ -75,11 +75,11 @@ You can use `colorWithDynamicProvider` to achieve this:
 
 The `colorWithDynamicProvider` will now listen to changes of current trait colleciton and update the background color accordingly.
 
-This is the result: 
+This is the result:
 
 <video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/yl1wj11gw3p3aufgwu1i' />
 
-?> 💡 If you are using Expo, you can use the [SystemUI](https://docs.expo.dev/versions/latest/sdk/system-ui/) library to achieve this but it can only set the appearance to a static color.  
+?> 💡 If you are using Expo, you can use the [SystemUI](https://docs.expo.dev/versions/latest/sdk/system-ui/) library to achieve this but it can only set the appearance to a static color.
 
 ## That's all
 Thanks for reading! I hope you found this article useful. If you have any questions or feedback feel free to reach out to me on [Twitter](https://twitter.com/o_kwasniewski).

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,12 +9,18 @@ const Header = () => (
       >
         okwasniewski
       </Link>
-      <div className="flex gap-6 text-gray-600 dark:text-gray-400">
+      <div className="flex gap-6 text-gray-600 dark:text-gray-400 text-sm">
         <Link
           href="/blog"
           className="hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
         >
           blog
+        </Link>
+        <Link
+          href="/videos"
+          className="hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+        >
+          videos
         </Link>
         <Link
           href="/contact"


### PR DESCRIPTION
## Summary

- Add new `/videos` page showcasing conference talks, podcasts, and tutorials
- Add "videos" link to site header navigation
- Fix trailing whitespace in blog post

## Videos included

**Conference Talks:**
- Tips & Tricks From the Ultimate Guide to RN Optimization 2025
- Make Your React (Native) App Feel Native
- React Native Apple Vision Pro (thegeekconf)
- React Native ❤️ Apple Vision Pro (React Universe Conf 2024)

**Podcasts:**
- Building v0 iOS and Fixing React Native Along the Way
- React Native for Apple Vision Pro and visionOS

**Tutorials:**
- Building React Native TurboModules with Swift - Complete Tutorial
- Building React Native TurboModules with Swift - Event Emitting