### PR TITLE
refactor: standardize layout and fix blog typos

### DIFF
--- a/app/apps/[slug]/page.tsx
+++ b/app/apps/[slug]/page.tsx
@@ -34,13 +34,13 @@ export default async function AppsPage({ params }: Props) {
   const { default: Content, meta } = post;
 
   return (
-    <div className="mt-10">
+    <>
       <h1 className="mb-4 text-3xl font-semibold dark:text-gray-200">
         {meta.title}
       </h1>
       <div className="mx-auto prose dark:prose-invert lg:prose-lg font-sans">
         <Content />
       </div>
-    </div>
+    </>
   );
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -11,9 +11,5 @@ export const metadata: Metadata = {
 export default async function BlogPage() {
   const posts = await getPosts({ directory: "blog", limit: -1 });
 
-  return (
-    <div className="mt-10">
-      <Blog posts={posts} />
-    </div>
-  );
+  return <Blog posts={posts} />;
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -7,9 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function ContactPage() {
-  return (
-    <div className="mt-10">
-      <ContactContent />
-    </div>
-  );
+  return <ContactContent />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
     <html lang="en-US" className={`${geist.variable} ${geist.className}`}>
       <body>
         <Header />
-        <main className="w-full max-w-[750px] px-6 mx-auto min-h-[88vh] py-8">
+        <main className="w-full max-w-[750px] px-6 mx-auto min-h-[88vh] py-8 mt-10">
           {children}
         </main>
         <Footer />

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -10,9 +10,5 @@ export const metadata: Metadata = {
 export default async function PortfolioPage() {
   const posts = await getPosts({ directory: "portfolio", limit: -1 });
 
-  return (
-    <div className="mt-10">
-      <Work posts={posts} />
-    </div>
-  );
+  return <Work posts={posts} />;
 }

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -8,9 +8,5 @@ export const metadata: Metadata = {
 };
 
 export default function VideosPage() {
-  return (
-    <div className="mt-10">
-      <VideosContent />
-    </div>
-  );
+  return <VideosContent />;
 }

--- a/content/blog/handling-window-resizing-in-visionos.mdx
+++ b/content/blog/handling-window-resizing-in-visionos.mdx
@@ -1,50 +1,51 @@
-
 export const meta = {
-  title: 'Handling window resizing behavior in visionOS',
-  subtitle: 'How to adapt window resizing behavior in your spatial app',
-  date: '2024-01-11',
+  title: "Handling window resizing behavior in visionOS",
+  subtitle: "How to adapt window resizing behavior in your spatial app",
+  date: "2024-01-11",
   badges: [
     {
-      text: 'Swift',
-      color: 'orange',
-    }
-  ]
-}
+      text: "Swift",
+      color: "orange",
+    },
+  ],
+};
 
 ## Contents
 
-
 ## Introduction
+
 Apple's new platform, visionOS, is second to macOS in allowing you to resize windows without any restrictions. This introduces new challenges in developing responsive UI interfaces. In this blog post, we will go over how you can adapt the behavior of your app's windows.
 
 _Disclaimer: This blog post assumes you have basic iOS development knowledge._
 
-## Getting started 
-First, let's create a new Xcode project. From the visionOS tab, choose 'App.' 
+## Getting started
+
+First, let's create a new Xcode project. From the visionOS tab, choose 'App.'
 
 Then, give your app a name and configure the project as shown below:
 
-<img src='https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/ub9gv9slgkclobl7muoa' />
+<img src="https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/ub9gv9slgkclobl7muoa" />
 
 ?> If you are using [React Native visionOS](https://github.com/callstack/react-native-visionos) with SwiftUI integration (or already have an app), you can skip this step.
 
 ## Add `AppDelegate` and `SceneDelegate`
-If you are porting an existing UIKit app to visionOS, you should already have `AppDelegate` and `SceneDelegate`; however, for SwiftUI projects, these are not created automatically. 
+
+If you are porting an existing UIKit app to visionOS, you should already have `AppDelegate` and `SceneDelegate`; however, for SwiftUI projects, these are not created automatically.
 
 To create them, click 'File' > 'New' and then create `AppDelegate.swift`.
 
 ```swift
 class AppDelegate: NSObject, UIApplicationDelegate {
     var window: UIWindow?
-    
+
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         let sceneConfig = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
         return sceneConfig
     }
 }
 ```
-In this class you need to implement one method `application(_:configurationForConnecting:options:)` create a new `UISceneConfiguration` and return it, we will get back to this.
 
+In this class you need to implement one method `application(_:configurationForConnecting:options:)` create a new `UISceneConfiguration` and return it, we will get back to this.
 
 Next, let's create `SceneDelegate`:
 
@@ -53,10 +54,11 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
   var window: UIWindow?
 }
 ```
+
 We will implement necessary methods in the next section.
 
+Set `UISceneConfiguration` delegate to be our newly created `SceneDelegate` class:
 
-Set `UISceneConfiguration` delegate to be our newly created `SceneDelegate` class: 
 ```swift {6}
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
@@ -73,7 +75,7 @@ Using `@UIApplicationDelegateAdaptor` property wrapper, we can now use our `AppD
 @main
 struct WindowResizingApp: App {
     @UIApplicationDelegateAdaptor var delegate: AppDelegate
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -82,9 +84,9 @@ struct WindowResizingApp: App {
 }
 ```
 
-
 ## Window resizing options
-Now let's discuss the available resizing options that we have: 
+
+Now let's discuss the available resizing options that we have:
 
 ```swift
 public enum ResizingRestrictions {
@@ -95,21 +97,37 @@ public enum ResizingRestrictions {
 ```
 
 ### `uniform`
+
 Allows users to resize your windows in an uniform way
 
-<video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/se06efmc2ghxpotdrbun' />
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/se06efmc2ghxpotdrbun"
+/>
 
 ### `freeform`
+
 Default setting, users can resize the window however they want
 
-<video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/avduepgjyluyolyyig1j' />
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/avduepgjyluyolyyig1j"
+/>
 
 ### `none`
-Prevent's users from resizing your window
 
-<video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/iad0clg4aymogktzjidk' />
+Prevents users from resizing your window
+
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/iad0clg4aymogktzjidk"
+/>
 
 ## Handling window resizing
+
 Now it's time to implement scene resizing. Let's return to the empty `SceneDelegate` we created earlier and implement the `scene(_:willConnectTo:options:)` method.
 
 ```swift {7-9}
@@ -118,7 +136,7 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
 
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 	guard let windowScene = (scene as? UIWindowScene) else { return }
-	
+
 	let preferences = UIWindowScene.GeometryPreferences.Vision()
 	preferences.resizingRestrictions = UIWindowScene.ResizingRestrictions.uniform // Set it to none or uniform
 	windowScene.requestGeometryUpdate(preferences)
@@ -126,11 +144,10 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
 }
 ```
 
-In the snippet above, I'm creating a new `UIWindowScene.GeometryPreferences.Vision()` class and setting its `resizingRestrictions` property to one of the options specified in the `ResizingRestrictions` enum. 
+In the snippet above, I'm creating a new `UIWindowScene.GeometryPreferences.Vision()` class and setting its `resizingRestrictions` property to one of the options specified in the `ResizingRestrictions` enum.
 
 Calling `windowScene.requestGeometryUpdate(preferences)` allows the maintenance of the specified geometry preference.
 
-
 ## That's all
-Thanks for reading! I hope you found this article useful. If you have any questions or feedback feel free to reach out to me on [Twitter](https://twitter.com/o_kwasniewski).
 
+Thanks for reading! I hope you found this article useful. If you have any questions or feedback feel free to reach out to me on [Twitter](https://twitter.com/o_kwasniewski).

--- a/content/blog/react-native-change-native-background-color.mdx
+++ b/content/blog/react-native-change-native-background-color.mdx
@@ -1,19 +1,18 @@
-
 export const meta = {
-  title: 'How to change root view background color in React Native for iOS?',
-  subtitle: 'Root-view background that adapts to light/dark mode on iOS',
-  date: '2023-12-02',
+  title: "How to change root view background color in React Native for iOS?",
+  subtitle: "Root-view background that adapts to light/dark mode on iOS",
+  date: "2023-12-02",
   badges: [
     {
-      text: 'React Native',
-      color: 'blue',
+      text: "React Native",
+      color: "blue",
     },
     {
-      text: 'iOS',
-      color: 'blue',
-    }
-  ]
-}
+      text: "iOS",
+      color: "blue",
+    },
+  ],
+};
 
 ## Contents
 
@@ -51,7 +50,11 @@ Now open `AppDelegate.mm` and override following method:
 
 This should give you following result:
 
-<video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/p3i9bbsdpvf2hs4agqub' />
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/p3i9bbsdpvf2hs4agqub"
+/>
 
 This looks great in one appearance, but what if you want to change the background color based on the current appearance? Let's say you want to have red background in light mode and blue background in dark mode.
 
@@ -73,16 +76,20 @@ You can use `colorWithDynamicProvider` to achieve this:
 }
 ```
 
-The `colorWithDynamicProvider` will now listen to changes of current trait colleciton and update the background color accordingly.
+The `colorWithDynamicProvider` will now listen to changes of current trait collection and update the background color accordingly.
 
 This is the result:
 
-<video controls width="100%" src='https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/yl1wj11gw3p3aufgwu1i' />
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/yl1wj11gw3p3aufgwu1i"
+/>
 
 ?> 💡 If you are using Expo, you can use the [SystemUI](https://docs.expo.dev/versions/latest/sdk/system-ui/) library to achieve this but it can only set the appearance to a static color.
 
 ## That's all
+
 Thanks for reading! I hope you found this article useful. If you have any questions or feedback feel free to reach out to me on [Twitter](https://twitter.com/o_kwasniewski).
 
 !> Huge thanks to [Riccardo Cipolleschi](https://twitter.com/CipolleschiR) for reviewing this article and providing valuable feedback.
-

--- a/content/blog/react-native-visionos-multi-window-apps.mdx
+++ b/content/blog/react-native-visionos-multi-window-apps.mdx
@@ -1,29 +1,29 @@
-
 export const meta = {
-  title: 'Building multi-window applications with React Native visionOS',
-  subtitle: 'Working with multiple windows',
-  date: '2024-03-22',
+  title: "Building multi-window applications with React Native visionOS",
+  subtitle: "Working with multiple windows",
+  date: "2024-03-22",
   badges: [
     {
-      text: 'React Native',
-      color: 'blue',
+      text: "React Native",
+      color: "blue",
     },
     {
-      text: 'visionOS',
-      color: 'orange',
-    }
-  ]
-}
+      text: "visionOS",
+      color: "orange",
+    },
+  ],
+};
 
 ## Contents
 
 ## Introduction
+
 React Native visionOS allows users to create multi-window applications, this feature allows you to build feature-rich apps that use full capabilities of the framework. In this blog post we will go over how you can build multi-window counter application with global state.
 
-<img src="https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/dwtjtsp2ehm7kekw6add"/>
-
+<img src="https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/dwtjtsp2ehm7kekw6add" />
 
 ## Setup
+
 In order to get started, let's create a new visionOS application using this command:
 
 ```sh
@@ -43,17 +43,18 @@ yarn visionos
 ```
 
 ## Adding second window
+
 Note: Adding new windows is described in detail in the [documentation](https://callstack.github.io/react-native-visionos-docs/api/window-manager).
 
 This process involves three steps:
+
 - Enable Multiple Window support
 - Add native entry point
 - Declare new JS component
 
-
 1. Enable multiple window support in `Info.plist` by changing `UIApplicationSupportsMultipleScenes` to `true`:
 
-<img src="https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/wellmzdbkz2dtvl8uvsy"/>
+<img src="https://res.cloudinary.com/dangiiuvf/image/upload/f_auto,q_auto/wellmzdbkz2dtvl8uvsy" />
 
 2. Add additional `RCTWindow` in `visionos/App.swift` with `reactContext`, which allows us to share pass data between JS and native. Make sure that the `id` is unique for each window and matches the one in the JS code.
 
@@ -75,9 +76,10 @@ struct MultiWindowAppApp: App {
 2. Declare new JS component in `index.js`
 
 Let's create a component that's going to be used as our window:
+
 ```tsx title="Counter.tsx"
-import React from 'react';
-import {View, Text, Button} from 'react-native';
+import React from "react";
+import { View, Text, Button } from "react-native";
 
 export const Counter = () => {
   return (
@@ -91,29 +93,30 @@ export const Counter = () => {
 ```
 
 And add it to `index.js` file:
+
 ```js title="index.js" {4} /'Counter'/#v
 AppRegistry.registerComponent(appName, () => App);
 
 // Additional windows
-AppRegistry.registerComponent('Counter', () => Counter);
+AppRegistry.registerComponent("Counter", () => Counter);
 ```
 
 Next, let's add some code to open and close the window:
 
 ```tsx title="App.tsx" {7} {16,17}
-import {WindowManager} from '@callstack/react-native-visionos';
-import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
-import Button from './Button';
+import { WindowManager } from "@callstack/react-native-visionos";
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import Button from "./Button";
 
 // Retrieve the window
-const counterWindow = WindowManager.getWindow('Counter');
+const counterWindow = WindowManager.getWindow("Counter");
 
 function App(): React.JSX.Element {
   return (
     <View style={styles.wrapper}>
       <Text style={styles.title}>
-        React Naitve visionOS MutliWindow example
+        React Native visionOS MultiWindow example
       </Text>
       <View style={styles.row}>
         <Button title="Open Window" onPress={() => counterWindow.open()} />
@@ -122,13 +125,12 @@ function App(): React.JSX.Element {
     </View>
   );
 }
-
 ```
-
 
 Pressing on buttons should open new window. We are all set! Now, let's discuss state managers.
 
 ## Choosing state manager
+
 In most cases choosing state manager lies in personal preferences, performance, API design and more. However when it comes to sharing data across multiple windows the options are limited. As you saw from the setup above we have separate **React roots**, one for each window. Which makes using state managers that require wrapping our app in a provider not a viable option.
 
 React Native is sharing the same javascript context across windows. Which makes it possible to either pass some custom store to the `App` and `Counter` or use a state manager like Zustand that does it for you without need to wrap the apps with a Provider.
@@ -142,7 +144,7 @@ yarn add zustand
 Create a file called `store.ts` and implement a simple store:
 
 ```ts title="store.ts"
-import {create} from 'zustand';
+import { create } from "zustand";
 
 type CounterStore = {
   count: number;
@@ -153,26 +155,26 @@ type CounterActions = {
   decrement: () => void;
 };
 
-export const useCounterStore = create<CounterStore & CounterActions>(set => ({
+export const useCounterStore = create<CounterStore & CounterActions>((set) => ({
   count: 0,
-  increment: () => set(state => ({count: state.count + 1})),
-  decrement: () => set(state => ({count: state.count - 1})),
+  increment: () => set((state) => ({ count: state.count + 1 })),
+  decrement: () => set((state) => ({ count: state.count - 1 })),
 }));
 ```
 
 Next, let's use the store in both of our windows (main one) and the Counter window:
 
 ```tsx title="App.tsx"
-import {WindowManager} from '@callstack/react-native-visionos';
-import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
-import Button from './Button';
-import {useCounterStore} from './store';
+import { WindowManager } from "@callstack/react-native-visionos";
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import Button from "./Button";
+import { useCounterStore } from "./store";
 
-const counterWindow = WindowManager.getWindow('Counter');
+const counterWindow = WindowManager.getWindow("Counter");
 
 function App(): React.JSX.Element {
-  const [count, increment, decrement] = useCounterStore(store => [
+  const [count, increment, decrement] = useCounterStore((store) => [
     store.count,
     store.increment,
     store.decrement,
@@ -181,7 +183,7 @@ function App(): React.JSX.Element {
   return (
     <View style={styles.wrapper}>
       <Text style={styles.title}>
-        React Naitve visionOS multi window example
+        React Native visionOS multi window example
       </Text>
       <View style={styles.row}>
         <Button title="Open Window" onPress={() => counterWindow.open()} />
@@ -201,13 +203,13 @@ function App(): React.JSX.Element {
 And inside of `Counter.tsx`:
 
 ```tsx title="Counter.tsx"
-import React from 'react';
-import {View, Text, StyleSheet} from 'react-native';
-import Button from './Button';
-import {useCounterStore} from './store';
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import Button from "./Button";
+import { useCounterStore } from "./store";
 
 export const Counter = () => {
-  const [count, increment, decrement] = useCounterStore(store => [
+  const [count, increment, decrement] = useCounterStore((store) => [
     store.count,
     store.increment,
     store.decrement,
@@ -225,13 +227,14 @@ export const Counter = () => {
 
 Now we have seamless data sharing across two windows! Demo:
 
-<video controls width="100%" src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/u1qr2jfbhs6kzdltrk1r" />
+<video
+  controls
+  width="100%"
+  src="https://res.cloudinary.com/dangiiuvf/video/upload/f_auto:video,q_auto/u1qr2jfbhs6kzdltrk1r"
+/>
 
 ## That's all
 
 And that's it! I hope you found this article useful. If you have any questions or feedback feel free to reach out to me on [Twitter](https://twitter.com/o_kwasniewski).
 
 For those interested in the sample code, you can find it in the [GitHub Repository](https://github.com/okwasniewski/react-native-visionos-multi-window).
-
-
-


### PR DESCRIPTION
## Summary

- Move `mt-10` wrapper to root layout, removing duplication from all page components
- Fix typos in 3 blog posts (colleciton → collection, React Naitve → React Native, Prevent's → Prevents)