### PR TITLE
feat(mdx): add copy-to-clipboard for code blocks

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,6 +1,9 @@
-import type { MDXComponents } from 'mdx/types';
+import type { MDXComponents } from "mdx/types";
+import { Pre } from "@/components/pre";
 
-// This file is required to use MDX in `app` directory.
 export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return components;
+  return {
+    pre: Pre,
+    ...components,
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3477,8 +3477,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -9063,8 +9062,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/src/components/Work.tsx
+++ b/src/components/Work.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Post } from "@/lib/getAllPosts";
-import { FiArrowRight } from "react-icons/fi";
+import { PostCard } from "./post-card";
 
 interface WorkProps {
   posts: Post[];
@@ -14,20 +14,7 @@ const Work = ({ posts, showAllLink = false }: WorkProps) => (
     </h2>
     <div>
       {posts.map(({ slug, meta }) => (
-        <Link key={slug} href={`/portfolio/${slug}`} className="block group">
-          <article className="py-3 border-b border-gray-200 dark:border-gray-800 last:border-b-0">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1 min-w-0">
-                <h3 className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
-                  {meta.title}
-                </h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
-                  {meta.subtitle}
-                </p>
-              </div>
-            </div>
-          </article>
-        </Link>
+        <PostCard key={slug} meta={meta} href={`/portfolio/${slug}`} compact />
       ))}
     </div>
     {showAllLink && (

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+
+interface CopyButtonProps {
+  getCode: () => string;
+}
+
+export function CopyButton({ getCode }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    const code = getCode();
+    if (!code) return;
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Fallback for Safari or older browsers
+      const textarea = document.createElement("textarea");
+      textarea.value = code;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      timerRef.current = window.setTimeout(() => setCopied(false), 2500);
+    }
+  }, [getCode]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy code"}
+      className="copy-button"
+    >
+      {copied ? (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/pre.tsx
+++ b/src/components/pre.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRef, useCallback, type ReactNode } from "react";
+import { CopyButton } from "./copy-button";
+
+interface PreProps extends React.HTMLAttributes<HTMLPreElement> {
+  children?: ReactNode;
+}
+
+export function Pre({ children, ...props }: PreProps) {
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const getCode = useCallback(() => {
+    return preRef.current?.querySelector("code")?.innerText ?? "";
+  }, []);
+
+  return (
+    <pre ref={preRef} {...props}>
+      <CopyButton getCode={getCode} />
+      {children}
+    </pre>
+  );
+}

--- a/src/components/pre.tsx
+++ b/src/components/pre.tsx
@@ -15,9 +15,11 @@ export function Pre({ children, ...props }: PreProps) {
   }, []);
 
   return (
-    <pre ref={preRef} {...props}>
+    <div className="pre-wrapper">
       <CopyButton getCode={getCode} />
-      {children}
-    </pre>
+      <pre ref={preRef} {...props}>
+        {children}
+      </pre>
+    </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -199,9 +199,15 @@ pre .copy-button {
   background: rgba(255, 255, 255, 0.1);
   color: #adadad;
   cursor: pointer;
+  opacity: 0;
   transition:
+    opacity 0.15s ease,
     color 0.15s ease,
     background 0.15s ease;
+}
+
+pre:hover .copy-button {
+  opacity: 1;
 }
 
 pre .copy-button:hover {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -182,14 +182,15 @@ figcaption + pre {
 }
 
 /* Copy button for code blocks */
-pre:has(code) {
+.pre-wrapper {
   position: relative;
 }
 
-pre .copy-button {
+.pre-wrapper .copy-button {
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
+  z-index: 1;
   padding: 0.25rem;
   display: flex;
   align-items: center;
@@ -206,11 +207,11 @@ pre .copy-button {
     background 0.15s ease;
 }
 
-pre:hover .copy-button {
+.pre-wrapper:hover .copy-button {
   opacity: 1;
 }
 
-pre .copy-button:hover {
+.pre-wrapper .copy-button:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.2);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -180,3 +180,31 @@ figcaption + pre {
 .prose code {
   font-weight: normal;
 }
+
+/* Copy button for code blocks */
+pre:has(code) {
+  position: relative;
+}
+
+pre .copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #adadad;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+pre .copy-button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.2);
+}


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard button to all code blocks via custom MDX `<Pre>` component
- Refactor `Work.tsx` to reuse `PostCard` component

## Changes
- `copy-button.tsx`: Client component with clipboard API + fallback for older browsers
- `pre.tsx`: Wraps `<pre>` elements, injects copy button
- `mdx-components.tsx`: Override default `pre` with custom component
- `globals.css`: Styling for copy button positioning and hover states
- `Work.tsx`: Replace inline markup with `PostCard` component