### PR TITLE
Enhance website for personal branding

### DIFF
--- a/app/contact/contact-content.tsx
+++ b/app/contact/contact-content.tsx
@@ -12,7 +12,8 @@ export default function ContactContent() {
         Contact
       </h1>
       <p className="text-gray-600 dark:text-gray-400 mb-8">
-        Feel free to reach out. I&apos;m most active on{" "}
+        Open to interesting conversations about React Native, native development, and open source.
+        I&apos;m most active on{" "}
         <Link
           href="https://x.com/o_kwasniewski"
           target="_blank"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Hero from "@/components/Hero";
 import Work from "@/components/Work";
 import Writing from "@/components/Writing";
+import Speaking from "@/components/Speaking";
 import { getPosts } from "@/lib/getAllPosts";
 
 export default async function HomePage() {
@@ -12,6 +13,7 @@ export default async function HomePage() {
       <Hero />
       <Work posts={projects} showAllLink />
       <Writing posts={posts} />
+      <Speaking />
     </>
   );
 }

--- a/app/videos/videos-content.tsx
+++ b/app/videos/videos-content.tsx
@@ -141,7 +141,7 @@ export default function VideosContent() {
         Videos
       </h1>
       <p className="text-gray-600 dark:text-gray-400 mb-8">
-        Conference talks, tutorials, and podcast appearances. Subscribe to my{" "}
+        {conferencesTalks.length} conference talks, {podcasts.length} podcast appearances, {tutorials.length} tutorials — and more coming. Subscribe to my{" "}
         <Link
           href="https://www.youtube.com/@okwasniewski-dev"
           target="_blank"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,12 @@ const Header = () => (
           blog
         </Link>
         <Link
+          href="/portfolio"
+          className="hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+        >
+          portfolio
+        </Link>
+        <Link
           href="/videos"
           className="hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
         >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 const Hero = () => (
   <section className="mb-16">
@@ -43,17 +44,17 @@ const Hero = () => (
       </p>
       <p>
         Creator of{" "}
-        <a href="/portfolio/react-native-visionos" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+        <Link href="/portfolio/react-native-visionos" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
           react-native-visionos
-        </a>
+        </Link>
         ,{" "}
-        <a href="/portfolio/react-native-bottom-tabs" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+        <Link href="/portfolio/react-native-bottom-tabs" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
           react-native-bottom-tabs
-        </a>
+        </Link>
         , and{" "}
-        <a href="/portfolio/liquid-glass" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+        <Link href="/portfolio/liquid-glass" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
           Liquid Glass
-        </a>
+        </Link>
         . Focused on bridging React Native with native platforms — iOS, Android, visionOS, macOS.
       </p>
       <p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -40,7 +40,7 @@ const Hero = () => (
         >
           Callstack
         </a>{" "}
-        for 3.5 years. Open source enthusiast with 100+ merged PRs to React Native Core.
+        Open source enthusiast with 100+ merged PRs to React Native Core.
       </p>
       <p>
         Creator of{" "}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -30,11 +30,34 @@ const Hero = () => (
         >
           Born
         </a>
-        . Open source enthusiast with 100+ merged PRs to React Native Core.
+        . Previously at{" "}
+        <a
+          href="https://callstack.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100"
+        >
+          Callstack
+        </a>{" "}
+        for 3.5 years. Open source enthusiast with 100+ merged PRs to React Native Core.
       </p>
       <p>
-        Focused on native development in Swift, Objective-C, Java and Kotlin. In
-        my free time I enjoy gravel cycling and learning new things.
+        Creator of{" "}
+        <a href="/portfolio/react-native-visionos" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+          react-native-visionos
+        </a>
+        ,{" "}
+        <a href="/portfolio/react-native-bottom-tabs" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+          react-native-bottom-tabs
+        </a>
+        , and{" "}
+        <a href="/portfolio/liquid-glass" className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100">
+          Liquid Glass
+        </a>
+        . Focused on bridging React Native with native platforms — iOS, Android, visionOS, macOS.
+      </p>
+      <p>
+        When not coding, I enjoy gravel cycling and building side projects.
       </p>
     </div>
   </section>

--- a/src/components/Speaking.tsx
+++ b/src/components/Speaking.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+const Speaking = () => (
+  <section className="mb-16">
+    <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+      Speaking
+    </h2>
+    <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
+      I speak at React Native conferences about native development, visionOS, and performance optimization.{" "}
+      <Link
+        href="/videos"
+        className="underline underline-offset-2 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+      >
+        Watch my talks →
+      </Link>
+    </p>
+  </section>
+);
+
+export default Speaking;


### PR DESCRIPTION
- Hero: Add Callstack mention, link to key projects (visionOS, bottom-tabs, liquid-glass)
- Header: Add portfolio link to navigation
- Contact: Update CTA to be more conversational
- Videos: Dynamic counts for talks/podcasts/tutorials
- Homepage: Add Speaking section with link to videos