### PR TITLE
feat(ui): add GitHub links to project rows

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ export default async function HomePage() {
   return (
     <>
       <Hero />
-      <Work posts={projects} showAllLink />
+      <Work posts={projects} showAllLink showPrimaryActionLink />
       <Writing posts={posts} />
       <Speaking />
     </>

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -10,5 +10,5 @@ export const metadata: Metadata = {
 export default async function PortfolioPage() {
   const posts = await getPosts({ directory: "portfolio", limit: -1 });
 
-  return <Work posts={posts} />;
+  return <Work posts={posts} showPrimaryActionLink />;
 }

--- a/content/portfolio/expo-icloud-storage.mdx
+++ b/content/portfolio/expo-icloud-storage.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: "Expo iCloud Storage",
   subtitle: "React Native wrapper for iCloud's NSUbiquitousKeyValueStore.",
+  github: "https://github.com/okwasniewski/expo-icloud-storage",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/okwasniewski/expo-icloud-storage",

--- a/content/portfolio/liquid-glass.mdx
+++ b/content/portfolio/liquid-glass.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: "Liquid Glass",
   subtitle: "iOS 26 liquid glass effect for React Native.",
+  github: "https://github.com/callstack/liquid-glass",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/callstack/liquid-glass",

--- a/content/portfolio/minisim.mdx
+++ b/content/portfolio/minisim.mdx
@@ -3,6 +3,7 @@ export const meta = {
   title: "MiniSim",
   subtitle: "MacOS menu bar app for launching iOS and Android 🤖 emulators.",
   featuredImage: "https://res.cloudinary.com/dangiiuvf/image/upload/w_800,q_auto/vgrduiaa685hd3d8sj3s",
+  github: "https://github.com/okwasniewski/minisim",
   primaryAction: { 
     text: 'Download the app',
     href: 'https://minisim.app',
@@ -47,4 +48,3 @@ Written in Swift and AppKit.
 ## Screenshots
 
 <img width="512" src="https://user-images.githubusercontent.com/52801365/223483262-aa3bad72-2948-4893-87a0-578e5d3d8e89.png"/>
-

--- a/content/portfolio/react-native-bottom-tabs.mdx
+++ b/content/portfolio/react-native-bottom-tabs.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: "React Native Bottom Tabs",
   subtitle: "Native bottom tabs for React Native, using platform primitives.",
+  github: "https://github.com/callstack/react-native-bottom-tabs",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/callstack/react-native-bottom-tabs",

--- a/content/portfolio/react-native-emoji-popup.mdx
+++ b/content/portfolio/react-native-emoji-popup.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: "React Native Emoji Popup",
   subtitle: "Native emoji picker popup for React Native.",
+  github: "https://github.com/okwasniewski/react-native-emoji-popup",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/okwasniewski/react-native-emoji-popup",

--- a/content/portfolio/react-native-menubar-extra.mdx
+++ b/content/portfolio/react-native-menubar-extra.mdx
@@ -3,6 +3,7 @@ export const meta = {
   title: "React Native MenuBar Extra",
   subtitle: "Easily add MenuBar to your React Native MacOS Application",
   featuredImage: "https://res.cloudinary.com/dangiiuvf/image/upload/w_800,q_auto/pxgjrwucriby0krwfxu4",
+  github: "https://github.com/okwasniewski/react-native-menubar-extra",
   primaryAction: { 
     text: 'Open GitHub',
     href: 'https://github.com/okwasniewski/react-native-menubar-extra',
@@ -57,4 +58,3 @@ const MenuBar = () => {
   );
 };
 ```
-

--- a/content/portfolio/react-native-svg-decoder.mdx
+++ b/content/portfolio/react-native-svg-decoder.mdx
@@ -2,6 +2,7 @@ export const meta = {
   title: "React Native SVG Decoder",
   subtitle:
     "Extends built-in Image component with SVG capabilities using CoreSVG.",
+  github: "https://github.com/okwasniewski/react-native-svg-decoder",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/okwasniewski/react-native-svg-decoder",

--- a/content/portfolio/react-native-visionos.mdx
+++ b/content/portfolio/react-native-visionos.mdx
@@ -1,6 +1,7 @@
 export const meta = {
   title: "React Native visionOS",
   subtitle: "Build spatial apps with React Native for Apple Vision Pro.",
+  github: "https://github.com/callstack/react-native-visionos",
   primaryAction: {
     text: "View on GitHub",
     href: "https://github.com/callstack/react-native-visionos",

--- a/src/components/Work.tsx
+++ b/src/components/Work.tsx
@@ -5,16 +5,27 @@ import { PostCard } from "./post-card";
 interface WorkProps {
   posts: Post[];
   showAllLink?: boolean;
+  showPrimaryActionLink?: boolean;
 }
 
-const Work = ({ posts, showAllLink = false }: WorkProps) => (
+const Work = ({
+  posts,
+  showAllLink = false,
+  showPrimaryActionLink = false,
+}: WorkProps) => (
   <section className="mb-16">
     <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
       Projects
     </h2>
     <div>
       {posts.map(({ slug, meta }) => (
-        <PostCard key={slug} meta={meta} href={`/portfolio/${slug}`} compact />
+        <PostCard
+          key={slug}
+          meta={meta}
+          href={`/portfolio/${slug}`}
+          compact
+          showPrimaryActionLink={showPrimaryActionLink}
+        />
       ))}
     </div>
     {showAllLink && (

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,34 +1,61 @@
 import Link from "next/link";
 import { PostMeta } from "@/lib/getAllPosts";
+import { FaGithub } from "react-icons/fa";
 
 interface PostCardProps {
   meta: PostMeta;
   href: string;
   compact?: boolean;
+  showPrimaryActionLink?: boolean;
 }
 
-export function PostCard({ meta, href, compact = false }: PostCardProps) {
+export function PostCard({
+  meta,
+  href,
+  compact = false,
+  showPrimaryActionLink = false,
+}: PostCardProps) {
+  const githubHref =
+    showPrimaryActionLink &&
+    meta.primaryAction &&
+    /github\.com/i.test(meta.primaryAction.href)
+      ? meta.primaryAction.href
+      : undefined;
+
   return (
-    <Link href={href} className="block group">
-      <article
-        className={`${compact ? "py-3" : "py-4"} border-b border-gray-200 dark:border-gray-800 last:border-b-0`}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <h3 className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
-              {meta.title}
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-              {meta.subtitle}
-            </p>
+    <article
+      className={`${compact ? "py-3" : "py-4"} border-b border-gray-200 dark:border-gray-800 last:border-b-0`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <Link href={href} className="block flex-1 min-w-0 group">
+          <h3 className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
+            {meta.title}
+          </h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            {meta.subtitle}
+          </p>
+        </Link>
+        {(githubHref || meta.date) && (
+          <div className="flex items-center gap-3 shrink-0">
+            {githubHref && (
+              <Link
+                href={githubHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Open ${meta.title ?? "project"} on GitHub`}
+                className="text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+              >
+                <FaGithub className="w-4 h-4" />
+              </Link>
+            )}
+            {meta.date && (
+              <span className="text-sm text-gray-400 dark:text-gray-500 shrink-0">
+                {meta.date}
+              </span>
+            )}
           </div>
-          {meta.date && (
-            <span className="text-sm text-gray-400 dark:text-gray-500 shrink-0">
-              {meta.date}
-            </span>
-          )}
-        </div>
-      </article>
-    </Link>
+        )}
+      </div>
+    </article>
   );
 }

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -9,24 +9,39 @@ interface PostCardProps {
   showPrimaryActionLink?: boolean;
 }
 
+function getValidGitHubUrl(value?: string): string | undefined {
+  if (!value) return undefined;
+
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) return undefined;
+
+    const host = url.hostname.toLowerCase();
+    if (host === "github.com" || host.endsWith(".github.com")) {
+      return value;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
 export function PostCard({
   meta,
   href,
   compact = false,
   showPrimaryActionLink = false,
 }: PostCardProps) {
-  const githubHref =
-    showPrimaryActionLink &&
-    meta.primaryAction &&
-    /github\.com/i.test(meta.primaryAction.href)
-      ? meta.primaryAction.href
-      : undefined;
+  const githubHref = showPrimaryActionLink
+    ? getValidGitHubUrl(meta.github)
+    : undefined;
 
   return (
     <article
-      className={`${compact ? "py-3" : "py-4"} border-b border-gray-200 dark:border-gray-800 last:border-b-0`}
+      className={`${compact ? "py-3" : "py-4"}`}
     >
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex items-center justify-between gap-4">
         <Link href={href} className="block flex-1 min-w-0 group">
           <h3 className="text-gray-900 dark:text-gray-100 font-medium group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors">
             {meta.title}

--- a/src/lib/getAllPosts.ts
+++ b/src/lib/getAllPosts.ts
@@ -6,6 +6,7 @@ export interface PostMeta {
   subtitle?: string;
   featuredImage?: string;
   date?: string;
+  github?: string;
   primaryAction?: {
     text: string;
     href: string;


### PR DESCRIPTION
## Summary

Add optional GitHub icon links to project list items on Home and Portfolio pages\n- Thread a new flag through Work/PostCard so only project lists render the icon\n- Use existing project metadata primaryAction hrefs (only GitHub links) for quick navigation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional primary action link on work cards to enable a dedicated primary link per item.
  * GitHub repository links added to portfolio entries and shown on cards when available.

* **Style**
  * Card layout updated: date moved into the right-side actions area alongside action links and the GitHub icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->