### PR TITLE
Add GitHub icon to project page action links

### DIFF
--- a/src/components/BlogHeader.tsx
+++ b/src/components/BlogHeader.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { PostMeta } from "@/lib/getAllPosts";
+import { FaGithub } from "react-icons/fa";
 
 type BlogHeaderProps = {
   title: string;
@@ -13,6 +14,11 @@ export default function BlogHeader({
   date,
   primaryAction,
 }: BlogHeaderProps) {
+  const showGitHubIcon =
+    primaryAction &&
+    (primaryAction.text.toLowerCase().includes("github") ||
+      primaryAction.href.toLowerCase().includes("github.com"));
+
   return (
     <header className="mb-10 pb-6 border-b border-gray-200 dark:border-gray-800">
       {date && (
@@ -27,8 +33,9 @@ export default function BlogHeader({
           href={primaryAction.href}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-gray-900 dark:text-gray-100 underline underline-offset-2 hover:text-gray-600 dark:hover:text-gray-400 transition-colors"
+          className="inline-flex items-center gap-1.5 text-gray-900 dark:text-gray-100 underline underline-offset-2 hover:text-gray-600 dark:hover:text-gray-400 transition-colors"
         >
+          {showGitHubIcon && <FaGithub className="w-4 h-4" />}
           {primaryAction.text} →
         </Link>
       )}


### PR DESCRIPTION
## Summary
- Show GitHub icon in blog/portfolio headers when primary action points to GitHub.
- Uses existing  icon and keeps behavior unchanged for non-GitHub actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub icon now automatically displays next to action links containing GitHub references, with improved visual layout and spacing for better visual consistency and recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->