### PR TITLE
fix(header): improve mobile navigation layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,15 @@
 import Link from "next/link";
 
 const Header = () => (
-  <header className="w-full max-w-[750px] mx-auto px-6 py-8">
-    <nav className="flex items-center justify-between">
+  <header className="w-full max-w-[750px] mx-auto px-6 py-6 sm:py-8">
+    <nav className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
       <Link
         href="/"
         className="text-gray-900 dark:text-gray-100 hover:opacity-70 transition-opacity font-bold"
       >
         okwasniewski
       </Link>
-      <div className="flex gap-6 text-gray-600 dark:text-gray-400 text-sm">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-gray-600 dark:text-gray-400 text-sm sm:justify-end sm:gap-6">
         <Link
           href="/blog"
           className="hover:text-gray-900 dark:hover:text-gray-100 transition-colors"


### PR DESCRIPTION
## Summary
- adjust header spacing on small screens
- make navigation responsive by stacking header content on mobile
- allow nav links to wrap cleanly to prevent overlap

## Validation
- npm run lint
- npm run build
- testerarmy run against localhost in 375x812 viewport
  - verified header links are visible, non-overlapping, and clickable
  - verified navigation works for Home, Blog, Portfolio, Videos, Contact

## Notes
- `next-sitemap` reports missing `siteUrl` in this local environment
