### PR TITLE
feat: change color scheme to orange

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,7 @@ const Header = () => (
         href="/"
         className="text-gray-900 dark:text-gray-100 hover:opacity-70 transition-opacity font-bold"
       >
-        okwasniewski
+        oskarkwasniewski
       </Link>
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-gray-600 dark:text-gray-400 text-sm sm:justify-end sm:gap-6">
         <Link

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -45,7 +45,7 @@ body {
 }
 
 .tip {
-  background-color: rgba(47, 129, 247, 0.15);
+  background-color: rgba(249, 115, 22, 0.15);
 }
 .warn {
   background-color: rgba(214, 119, 64, 0.15);
@@ -80,13 +80,13 @@ code {
 
 @media (prefers-color-scheme: dark) {
   code {
-    color: #82aaff;
+    color: #fb923c;
   }
 }
 
 @media (prefers-color-scheme: light) {
   code {
-    color: #001080;
+    color: #c2410c;
   }
 }
 
@@ -127,8 +127,8 @@ pre [data-line] {
 }
 
 [data-highlighted-line] {
-  background: rgba(200, 200, 255, 0.1);
-  @apply border-l-blue-400;
+  background: rgba(251, 146, 60, 0.1);
+  @apply border-l-orange-400;
 }
 
 [data-highlighted-chars] {


### PR DESCRIPTION
## Summary
- Replace blue accent colors with orange throughout the site
- Update code syntax highlighting colors (dark: `#fb923c`, light: `#c2410c`)
- Change highlighted line border from blue to orange
- Update tip hint background to orange tint